### PR TITLE
Fix missing retain on CBUUID::from_uuid.

### DIFF
--- a/src/corebluetooth/types.rs
+++ b/src/corebluetooth/types.rs
@@ -293,7 +293,7 @@ impl CBUUID {
         unsafe {
             let obj: *mut Self =
                 msg_send![Self::class(), UUIDWithData: NSData::from_vec(uuid.as_bluetooth_bytes().to_vec())];
-            Id::from_retained_ptr(obj)
+            Id::from_ptr(obj)
         }
     }
 


### PR DESCRIPTION
UUIDWithData doesn't return a retained ptr, so we have to retain it. Without this, we were seeing crashes after scanning when dropping the adapter.