### PR TITLE
Added missing `ready` function inside the `adapter.rs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ futures-core = "0.3.28"
 futures-lite = { version = "1.13.0", default-features = false }
 serde = { version = "1.0.143", optional = true, features = ["derive"] }
 tracing = { version = "0.1.36", default-features = false }
-tokio_stream = "0.1.14"
+tokio-stream = { version = "0.1.14", features = ["sync"] }
 
 [dev-dependencies]
 tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ futures-core = "0.3.28"
 futures-lite = { version = "1.13.0", default-features = false }
 serde = { version = "1.0.143", optional = true, features = ["derive"] }
 tracing = { version = "0.1.36", default-features = false }
+tokio_stream = "0.1.14"
 
 [dev-dependencies]
 tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread", "time"] }

--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -2,6 +2,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::future::ready;
 
 use futures_core::Stream;
 use futures_lite::{stream, StreamExt};

--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -2,7 +2,10 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+
+#[cfg(not(target_os = "macos"))]
 use std::future::ready;
+#[cfg(not(target_os = "macos"))]
 use tokio_stream::wrappers::BroadcastStream;
 
 use futures_core::Stream;

--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -3,6 +3,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::future::ready;
+use tokio_stream::wrappers::BroadcastStream;
 
 use futures_core::Stream;
 use futures_lite::{stream, StreamExt};


### PR DESCRIPTION
Added missing references.

```rust
use std::future::ready;
use tokio_stream::wrappers::BroadcastStream;
```

Also added `tokio_stream = "0.1.14"` to `Cargo.toml`