### PR TITLE
android: switch from futures-channel to async-channel.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ tokio = { version = "1.20.1", features = ["rt-multi-thread"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 java-spaghetti = "0.1.0"
-futures-channel = "0.3.24"
+async-channel = "2.2.0"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 async-broadcast = "0.5.1"


### PR DESCRIPTION
`futures-channel` doesn't support blocking send, so in the callbacks from java
(which are not in an async context) we're forced to do `try_send`, which will lose
data if the channel is full because the Rust side is too busy.

This is not a big deal for scanning, but is for stuff like gatt/l2cap responses that
are coming next.
