### PR TITLE
Add Linux and CoreBluetooth L2Cap Channels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ targets = [
 
 [features]
 serde = ["dep:serde", "uuid/serde", "bluer/serde"]
+l2cap = ["dep:tokio", "bluer/l2cap"]
 
 [dependencies]
 async-trait = "0.1.57"
@@ -30,7 +31,12 @@ serde = { version = "1.0.143", optional = true, features = ["derive"] }
 tracing = { version = "0.1.36", default-features = false }
 
 [dev-dependencies]
-tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread", "time"] }
+tokio = { version = "1.20.1", features = [
+    "macros",
+    "rt-multi-thread",
+    "time",
+    "io-util",
+] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
@@ -57,13 +63,19 @@ tokio = { version = "1.20.1", features = ["rt-multi-thread"] }
 [target.'cfg(target_os = "android")'.dependencies]
 java-spaghetti = "0.2.0"
 async-channel = "2.2.0"
+tokio = { version = "1.20.1", features = ["rt", "io-util"], optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 async-broadcast = "0.5.1"
 objc = "0.2.7"
 objc_id = "0.1.1"
 objc-foundation = "0.1.1"
+tokio = { version = "1.20.1", features = ["net"], optional = true }
 
 [[example]]
 name = "scan"
 doc-scrape-examples = true
+
+[[example]]
+name = "l2cap_client"
+required-features = ["l2cap"]

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ below.
 | [`Device::pair_with_agent`][Device::pair_with_agent]             |    ✨     |   ✅    |  ✅   |
 | [`Device::unpair`][Device::unpair]                               |    ❌     |   ✅    |  ✅   |
 | [`Device::rssi`][Device::rssi]                                   |    ✅     |   ❌    |  ❌   |
+| [`Device::open_l2cap_channel`][Device::open_l2cap_channel]       |    ⌛️     |   ❌    |  ⌛️   |
 | [`Service::uuid`][Service::uuid]                                 |    ✅     |   ✅    |  ⌛️   |
 | [`Service::is_primary`][Service::is_primary]                     |    ✅     |   ❌    |  ✅   |
 | [`Characteristic::uuid`][Characteristic::uuid]                   |    ✅     |   ✅    |  ⌛️   |
@@ -149,6 +150,7 @@ Refer to the [API documentation] for more details.
 [Device::unpair]: https://docs.rs/bluest/latest/bluest/struct.Device.html#method.unpair
 [Device::discover_services]: https://docs.rs/bluest/latest/bluest/struct.Device.html#method.discover_services
 [Device::rssi]: https://docs.rs/bluest/latest/bluest/struct.Device.html#method.rssi
+[Device::open_l2cap_channel]: https://docs.rs/bluest/latest/bluest/struct.Device.html#method.open_l2cap_channel
 [Service::uuid]: https://docs.rs/bluest/latest/bluest/struct.Service.html#method.uuid
 [Service::is_primary]: https://docs.rs/bluest/latest/bluest/struct.Service.html#method.is_primary
 [Service::discover_characteristics]: https://docs.rs/bluest/latest/bluest/struct.Service.html#method.discover_characteristics

--- a/examples/l2cap_client.rs
+++ b/examples/l2cap_client.rs
@@ -1,0 +1,64 @@
+// This is designed to be used in conjunction with the l2cap_server example from bluer. https://github.com/bluez/bluer/blob/869dab889140e3be5a0f1791c40825730893c8b6/bluer/examples/l2cap_server.rs
+
+use std::error::Error;
+
+use bluest::{Adapter, Uuid as BluestUUID};
+use futures_lite::StreamExt;
+use tokio::io::AsyncReadExt;
+use tracing::info;
+use tracing::metadata::LevelFilter;
+
+#[cfg(target_os = "linux")]
+const SERVICE_UUID: BluestUUID = bluer::Uuid::from_u128(0xFEED0000F00D);
+
+#[cfg(not(target_os = "linux"))]
+use uuid::Uuid;
+#[cfg(not(target_os = "linux"))]
+const SERVICE_UUID: BluestUUID = Uuid::from_u128(0xFEED0000F00D);
+
+const PSM: u16 = 0x80 + 5;
+
+const HELLO_MSG: &[u8] = b"Hello from l2cap_server!";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    use tracing_subscriber::prelude::*;
+    use tracing_subscriber::{fmt, EnvFilter};
+
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    let adapter = Adapter::default().await.unwrap();
+    adapter.wait_available().await?;
+
+    info!("looking for device");
+    let device = adapter
+        .discover_devices(&[SERVICE_UUID])
+        .await?
+        .next()
+        .await
+        .ok_or("Failed to discover device")??;
+    info!(
+        "found device: {} ({:?})",
+        device.name().as_deref().unwrap_or("(unknown)"),
+        device.id()
+    );
+
+    adapter.connect_device(&device).await.unwrap();
+
+    let mut channel = device.open_l2cap_channel(PSM, true).await.unwrap();
+
+    info!("Reading from channel.");
+    let mut hello_buf = [0u8; HELLO_MSG.len()];
+    channel.read_exact(&mut hello_buf).await.unwrap();
+
+    info!("Got {} from channel", std::str::from_utf8(&hello_buf).unwrap());
+    assert_eq!(hello_buf, HELLO_MSG);
+    Ok(())
+}

--- a/src/android/device.rs
+++ b/src/android/device.rs
@@ -4,13 +4,14 @@ use java_spaghetti::Global;
 use uuid::Uuid;
 
 use super::bindings::android::bluetooth::BluetoothDevice;
-use super::l2cap_channel::{L2capChannelReader, L2capChannelWriter};
 use crate::pairing::PairingAgent;
 use crate::{DeviceId, Result, Service, ServicesChanged};
 
 #[derive(Clone)]
 pub struct DeviceImpl {
     pub(super) id: DeviceId,
+
+    #[allow(unused)]
     pub(super) device: Global<BluetoothDevice>,
 }
 
@@ -97,12 +98,9 @@ impl DeviceImpl {
         todo!()
     }
 
-    pub async fn open_l2cap_channel(
-        &self,
-        psm: u16,
-        secure: bool,
-    ) -> std::prelude::v1::Result<(L2capChannelReader, L2capChannelWriter), crate::Error> {
-        super::l2cap_channel::open_l2cap_channel(self.device.clone(), psm, secure)
+    #[cfg(feature = "l2cap")]
+    pub async fn open_l2cap_channel(&self, psm: u16, secure: bool) -> Result<super::l2cap_channel::Channel> {
+        super::l2cap_channel::Channel::new(self.device.clone(), psm, secure)
     }
 }
 

--- a/src/android/l2cap_channel.rs
+++ b/src/android/l2cap_channel.rs
@@ -1,11 +1,7 @@
-use std::{
-    fmt,
-    io::Result,
-    pin::Pin,
-    slice,
-    task::{Context, Poll},
-    thread,
-};
+use std::io::Result;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::{fmt, slice, thread};
 
 use java_spaghetti::{ByteArray, Global, Local, PrimitiveArray};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, DuplexStream, ReadBuf};

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -7,8 +7,10 @@ pub mod adapter;
 pub mod characteristic;
 pub mod descriptor;
 pub mod device;
-pub mod l2cap_channel;
 pub mod service;
+
+#[cfg(feature = "l2cap")]
+pub mod l2cap_channel;
 
 pub(crate) mod bindings;
 

--- a/src/bluer.rs
+++ b/src/bluer.rs
@@ -2,8 +2,10 @@ pub mod adapter;
 pub mod characteristic;
 pub mod descriptor;
 pub mod device;
-pub mod l2cap_channel;
 pub mod service;
+
+#[cfg(feature = "l2cap")]
+pub mod l2cap_channel;
 
 mod error;
 

--- a/src/bluer/device.rs
+++ b/src/bluer/device.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use futures_core::Stream;
 use futures_lite::StreamExt;
 
-use super::l2cap_channel::{L2capChannelReader, L2capChannelWriter};
 use super::DeviceId;
 use crate::device::ServicesChanged;
 use crate::error::ErrorKind;
@@ -292,12 +291,17 @@ impl DeviceImpl {
         }
     }
 
-    pub async fn open_l2cap_channel(
-        &self,
-        _psm: u16,
-        _secure: bool,
-    ) -> std::prelude::v1::Result<(L2capChannelReader, L2capChannelWriter), crate::Error> {
-        Err(ErrorKind::NotSupported.into())
+    #[cfg(feature = "l2cap")]
+    pub async fn open_l2cap_channel(&self, psm: u16, secure: bool) -> Result<super::l2cap_channel::Channel> {
+        let address_type = self.inner.address_type().await.map_err(|err| {
+            crate::Error::new(
+                crate::error::ErrorKind::Internal,
+                Some(Box::new(err)),
+                "Could not get address".to_owned(),
+            )
+        })?;
+        let sa = bluer::l2cap::SocketAddr::new(self.inner.address(), address_type, psm);
+        super::l2cap_channel::Channel::new(sa, secure).await
     }
 }
 

--- a/src/bluer/l2cap_channel.rs
+++ b/src/bluer/l2cap_channel.rs
@@ -1,8 +1,6 @@
-use std::{
-    io::Result,
-    pin::Pin,
-    task::{Context, Poll},
-};
+use std::io::Result;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 use bluer::l2cap::{SocketAddr, Stream};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};

--- a/src/corebluetooth.rs
+++ b/src/corebluetooth.rs
@@ -5,8 +5,10 @@ pub mod characteristic;
 pub mod descriptor;
 pub mod device;
 pub mod error;
-pub mod l2cap_channel;
 pub mod service;
+
+#[cfg(feature = "l2cap")]
+pub mod l2cap_channel;
 
 mod delegates;
 mod types;

--- a/src/corebluetooth/delegates.rs
+++ b/src/corebluetooth/delegates.rs
@@ -116,7 +116,7 @@ pub enum PeripheralEvent {
         invalidated_services: Vec<ShareId<CBService>>,
     },
     L2CAPChannelOpened {
-        channel: ShareId<CBL2CAPChannel>,
+        channel: Option<ShareId<CBL2CAPChannel>>,
         error: Option<ShareId<NSError>>,
     },
 }
@@ -537,7 +537,7 @@ impl PeripheralDelegate {
     delegate_method!(did_read_rssi<ReadRssi>(peripheral, rssi: i16, error: Option));
     delegate_method!(did_update_name<NameUpdate>(peripheral));
     delegate_method!(did_modify_services<ServicesChanged>(peripheral, invalidated_services: Vec));
-    delegate_method!(did_open_l2cap_channel<L2CAPChannelOpened>(peripheral, channel: Object, error: Option));
+    delegate_method!(did_open_l2cap_channel<L2CAPChannelOpened>(peripheral, channel: Option, error: Option));
 
     fn class() -> &'static Class {
         static DELEGATE_CLASS_INIT: Once = Once::new();

--- a/src/corebluetooth/device.rs
+++ b/src/corebluetooth/device.rs
@@ -6,14 +6,13 @@ use objc_foundation::{INSArray, INSFastEnumeration, INSString, NSArray};
 use objc_id::ShareId;
 
 use super::delegates::{PeripheralDelegate, PeripheralEvent};
+#[cfg(feature = "l2cap")]
+use super::l2cap_channel::Channel;
 use super::types::{CBPeripheral, CBPeripheralState, CBService, CBUUID};
 use crate::device::ServicesChanged;
 use crate::error::ErrorKind;
 use crate::pairing::PairingAgent;
 use crate::{Device, DeviceId, Error, Result, Service, Uuid};
-
-#[cfg(feature = "l2cap")]
-use super::l2cap_channel::Channel;
 
 /// A Bluetooth LE device
 #[derive(Clone)]

--- a/src/corebluetooth/l2cap_channel.rs
+++ b/src/corebluetooth/l2cap_channel.rs
@@ -1,52 +1,133 @@
-use std::fmt;
+use std::{
+    io::Result,
+    os::fd::{FromRawFd, RawFd},
+    pin::Pin,
+    task::{Context, Poll},
+};
 
-use crate::Result;
+use objc_foundation::INSData;
+use objc_id::{Id, Shared};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    net::UnixStream,
+};
 
-pub struct L2capChannelReader {
-    _private: (),
+use super::types::{kCFStreamPropertySocketNativeHandle, CBL2CAPChannel, CFStream};
+use crate::{error::ErrorKind, Error};
+
+// This implementation is based upon the fact that that CBL2CAPChannel::outputStream -> an NS Output Stream; (https://developer.apple.com/documentation/foundation/outputstream)
+// NS Output stream is toll free bridged to CFWriteStream (https://developer.apple.com/documentation/corefoundation/cfwritestream)
+// CFWriteStream is a subclass of CFStream (https://developer.apple.com/documentation/corefoundation/cfstream?language=objc)
+// CF Stream has properties (https://developer.apple.com/documentation/corefoundation/cfstream/stream_properties?language=objc)
+// One of them is kCFStreamPropertySocketNativeHandle https://developer.apple.com/documentation/corefoundation/kcfstreampropertysocketnativehandle?language=objc
+// kCFStreamPropertySocketNativeHandle is of type CFSocketNativeHandle https://developer.apple.com/documentation/corefoundation/cfsocketnativehandle?language=objc
+// CFSocketNativeHandle is a property of CFSocket https://developer.apple.com/documentation/corefoundation/cfsocket?language=objc
+// CF Socket is defined to be a bsd socket
+// BSD Sockets are Unix Sockets on mac os
+
+#[derive(Debug)]
+pub struct Channel {
+    _channel: Id<CBL2CAPChannel, Shared>,
+    stream: Pin<Box<UnixStream>>,
 }
 
-impl L2capChannelReader {
-    #[inline]
-    pub async fn read(&mut self, _buf: &mut [u8]) -> Result<usize> {
-        todo!()
-    }
+enum ChannelCreationError {
+    FileDescriptorPropertyNotValid,
+    InputFileDescriptorBytesWrongSize,
+    OutputFileDescriptorBytesWrongSize,
+    FileDescriptorsNotIdentical,
+    SetNonBlockingModeFailed(std::io::Error),
+    TokioStreamCreation(std::io::Error),
+}
 
-    pub fn try_read(&mut self, _buf: &mut [u8]) -> Result<usize> {
-        todo!()
-    }
+impl Channel {
+    pub fn new(channel: Id<CBL2CAPChannel, Shared>) -> crate::Result<Self> {
+        let input_stream = channel.input_stream();
+        let output_stream = channel.output_stream();
 
-    pub async fn close(&mut self) -> Result<()> {
-        todo!()
+        let in_stream_prop = input_stream.property(&unsafe { kCFStreamPropertySocketNativeHandle });
+        let out_stream_prop = output_stream.property(&unsafe { kCFStreamPropertySocketNativeHandle });
+
+        let (Some(in_data), Some(out_data)) = (in_stream_prop, out_stream_prop) else {
+            return Err(ChannelCreationError::FileDescriptorPropertyNotValid.into());
+        };
+        let in_bytes = in_data
+            .bytes()
+            .try_into()
+            .map_err(|_| ChannelCreationError::InputFileDescriptorBytesWrongSize)?;
+        let in_fd = RawFd::from_ne_bytes(in_bytes);
+
+        let out_bytes = out_data
+            .bytes()
+            .try_into()
+            .map_err(|_| ChannelCreationError::OutputFileDescriptorBytesWrongSize)?;
+        let out_fd = RawFd::from_ne_bytes(out_bytes);
+
+        if in_fd != out_fd {
+            return Err(ChannelCreationError::FileDescriptorsNotIdentical.into());
+        };
+
+        let stream = unsafe { std::os::unix::net::UnixStream::from_raw_fd(in_fd) };
+        stream
+            .set_nonblocking(true)
+            .map_err(ChannelCreationError::SetNonBlockingModeFailed)?;
+
+        let tokio_stream = UnixStream::try_from(stream).map_err(ChannelCreationError::TokioStreamCreation)?;
+
+        let stream = Box::pin(tokio_stream);
+
+        Ok(Self {
+            _channel: channel,
+            stream,
+        })
+    }
+}
+impl AsyncRead for Channel {
+    fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>) -> Poll<std::io::Result<()>> {
+        self.stream.as_mut().poll_read(cx, buf)
     }
 }
 
-impl fmt::Debug for L2capChannelReader {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("L2capChannelReader")
+impl AsyncWrite for Channel {
+    fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize>> {
+        self.stream.as_mut().poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        self.stream.as_mut().poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        self.stream.as_mut().poll_shutdown(cx)
     }
 }
 
-pub struct L2capChannelWriter {
-    _private: (),
-}
+impl From<ChannelCreationError> for Error {
+    fn from(value: ChannelCreationError) -> Self {
+        let message = match &value {
+            ChannelCreationError::FileDescriptorPropertyNotValid => "File descriptor property not valid.",
+            ChannelCreationError::InputFileDescriptorBytesWrongSize => {
+                "Input file descriptor bytes are an invalid size."
+            }
+            ChannelCreationError::OutputFileDescriptorBytesWrongSize => {
+                "Output file descriptor bytes are an invalid size."
+            }
+            ChannelCreationError::FileDescriptorsNotIdentical => "Input and output file descriptors are not identical.",
+            ChannelCreationError::SetNonBlockingModeFailed(_) => "Could not get convert socket to async.",
+            ChannelCreationError::TokioStreamCreation(_) => "Failed to create tokio unix socket.",
+        };
 
-impl L2capChannelWriter {
-    pub async fn write(&mut self, _packet: &[u8]) -> Result<()> {
-        todo!()
-    }
-
-    pub fn try_write(&mut self, _packet: &[u8]) -> Result<()> {
-        todo!()
-    }
-
-    pub async fn close(&mut self) -> Result<()> {
-        todo!()
-    }
-}
-
-impl fmt::Debug for L2capChannelWriter {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("L2capChannelWriter")
+        Error::new(
+            ErrorKind::Internal,
+            match value {
+                ChannelCreationError::FileDescriptorPropertyNotValid
+                | ChannelCreationError::InputFileDescriptorBytesWrongSize
+                | ChannelCreationError::OutputFileDescriptorBytesWrongSize
+                | ChannelCreationError::FileDescriptorsNotIdentical => None,
+                ChannelCreationError::SetNonBlockingModeFailed(src)
+                | ChannelCreationError::TokioStreamCreation(src) => Some(Box::new(src)),
+            },
+            message.to_owned(),
+        )
     }
 }

--- a/src/corebluetooth/l2cap_channel.rs
+++ b/src/corebluetooth/l2cap_channel.rs
@@ -1,19 +1,16 @@
-use std::{
-    io::Result,
-    os::fd::{FromRawFd, RawFd},
-    pin::Pin,
-    task::{Context, Poll},
-};
+use std::io::Result;
+use std::os::fd::{FromRawFd, RawFd};
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 use objc_foundation::INSData;
 use objc_id::{Id, Shared};
-use tokio::{
-    io::{AsyncRead, AsyncWrite, ReadBuf},
-    net::UnixStream,
-};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::net::UnixStream;
 
 use super::types::{kCFStreamPropertySocketNativeHandle, CBL2CAPChannel, CFStream};
-use crate::{error::ErrorKind, Error};
+use crate::error::ErrorKind;
+use crate::Error;
 
 // This implementation is based upon the fact that that CBL2CAPChannel::outputStream -> an NS Output Stream; (https://developer.apple.com/documentation/foundation/outputstream)
 // NS Output stream is toll free bridged to CFWriteStream (https://developer.apple.com/documentation/corefoundation/cfwritestream)

--- a/src/corebluetooth/types.rs
+++ b/src/corebluetooth/types.rs
@@ -621,6 +621,8 @@ pub(super) unsafe trait NSStream: Sized + Message {
     }
 }
 
+/// # Safety
+/// Only implement for objective C object that inherit from CFStream (https://developer.apple.com/documentation/corefoundation/cfstream)
 pub(super) unsafe trait CFStream: Sized + Message {
     fn property(&self, key: &id) -> Option<&NSData> {
         let key = unsafe { extern_nsstring(*key) };

--- a/src/device.rs
+++ b/src/device.rs
@@ -4,11 +4,10 @@ use futures_core::Stream;
 use futures_lite::StreamExt;
 
 use crate::error::ErrorKind;
-use crate::pairing::PairingAgent;
-use crate::{sys, DeviceId, Error, Result, Service, Uuid};
-
 #[cfg(feature = "l2cap")]
 use crate::l2cap_channel::L2capChannel;
+use crate::pairing::PairingAgent;
+use crate::{sys, DeviceId, Error, Result, Service, Uuid};
 
 /// A Bluetooth LE device
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/device.rs
+++ b/src/device.rs
@@ -4,9 +4,11 @@ use futures_core::Stream;
 use futures_lite::StreamExt;
 
 use crate::error::ErrorKind;
-use crate::l2cap_channel::L2capChannel;
 use crate::pairing::PairingAgent;
 use crate::{sys, DeviceId, Error, Result, Service, Uuid};
+
+#[cfg(feature = "l2cap")]
+use crate::l2cap_channel::L2capChannel;
 
 /// A Bluetooth LE device
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -158,11 +160,14 @@ impl Device {
     ///
     /// # Platform specific
     ///
-    /// Returns [`NotSupported`][crate::error::ErrorKind::NotSupported] on iOS/MacOS, Windows and Linux.
+    /// Returns [`NotSupported`][crate::error::ErrorKind::NotSupported] on Windows.
+    #[cfg(feature = "l2cap")]
     #[inline]
     pub async fn open_l2cap_channel(&self, psm: u16, secure: bool) -> Result<L2capChannel> {
-        let (reader, writer) = self.0.open_l2cap_channel(psm, secure).await?;
-        Ok(L2capChannel { reader, writer })
+        let channel = self.0.open_l2cap_channel(psm, secure).await?;
+        Ok(L2capChannel {
+            channel: Box::pin(channel),
+        })
     }
 }
 

--- a/src/l2cap_channel.rs
+++ b/src/l2cap_channel.rs
@@ -1,114 +1,35 @@
-use crate::{sys, Result};
+use std::{
+    io::Result,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+use crate::sys;
 
 /// A Bluetooth LE L2CAP Connection-oriented Channel (CoC)
 #[derive(Debug)]
 pub struct L2capChannel {
-    pub(crate) reader: sys::l2cap_channel::L2capChannelReader,
-    pub(crate) writer: sys::l2cap_channel::L2capChannelWriter,
+    pub(crate) channel: Pin<Box<sys::l2cap_channel::Channel>>,
 }
 
-/// Reader half of a L2CAP Connection-oriented Channel (CoC)
-#[derive(Debug)]
-pub struct L2capChannelReader {
-    reader: sys::l2cap_channel::L2capChannelReader,
-}
-
-/// Writerhalf of a L2CAP Connection-oriented Channel (CoC)
-#[derive(Debug)]
-pub struct L2capChannelWriter {
-    writer: sys::l2cap_channel::L2capChannelWriter,
-}
-
-impl L2capChannel {
-    /// Read a packet from the L2CAP channel.
-    ///
-    /// The packet is written to the start of `buf`, and the packet length is returned.
-    #[inline]
-    pub async fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        self.reader.read(buf).await
-    }
-
-    /// Write a packet to the L2CAP channel.
-    #[inline]
-    pub async fn write(&mut self, packet: &[u8]) -> Result<()> {
-        self.writer.write(packet).await
-    }
-
-    /// Close the L2CAP channel.
-    ///
-    /// This closes the entire channel, in both directions (reading and writing).
-    ///
-    /// The channel is automatically closed when `L2capChannel` is dropped, so
-    /// you don't need to call this explicitly.
-    #[inline]
-    pub async fn close(&mut self) -> Result<()> {
-        self.writer.close().await
-    }
-
-    /// Split the channel into read and write halves.
-    #[inline]
-    pub fn split(self) -> (L2capChannelReader, L2capChannelWriter) {
-        let Self { reader, writer } = self;
-        (L2capChannelReader { reader }, L2capChannelWriter { writer })
+impl AsyncRead for L2capChannel {
+    fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>) -> Poll<Result<()>> {
+        self.channel.as_mut().poll_read(cx, buf)
     }
 }
 
-impl L2capChannelReader {
-    /// Read a packet from the L2CAP channel.
-    ///
-    /// The packet is written to the start of `buf`, and the packet length is returned.
-    #[inline]
-    pub async fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        self.reader.read(buf).await
+impl AsyncWrite for L2capChannel {
+    fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize>> {
+        self.channel.as_mut().poll_write(cx, buf)
     }
 
-    /// Try reading a packet from the L2CAP channel.
-    ///
-    /// The packet is written to the start of `buf`, and the packet length is returned.
-    ///
-    /// If no packet is immediately available for reading, this returns an error with kind `NotReady`.
-    #[inline]
-    pub fn try_read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        self.reader.try_read(buf)
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        self.channel.as_mut().poll_flush(cx)
     }
 
-    /// Close the L2CAP channel.
-    ///
-    /// This closes the entire channel, not just the read half.
-    ///
-    /// The channel is automatically closed when both the `L2capChannelWriter`
-    /// and `L2capChannelReader` are dropped, so you don't need to call this explicitly.
-    #[inline]
-    pub async fn close(&mut self) -> Result<()> {
-        self.reader.close().await
-    }
-}
-
-impl L2capChannelWriter {
-    /// Write a packet to the L2CAP channel.
-    ///
-    /// If the buffer is full, this will wait until there's buffer space for the packet.
-    #[inline]
-    pub async fn write(&mut self, packet: &[u8]) -> Result<()> {
-        self.writer.write(packet).await
-    }
-
-    /// Try writing a packet to the L2CAP channel.
-    ///
-    /// If there's no buffer space, this returns an error with kind `NotReady`.
-    #[inline]
-    pub fn try_write(&mut self, packet: &[u8]) -> Result<()> {
-        self.writer.try_write(packet)
-    }
-
-    /// Close the L2CAP channel.
-    ///
-    /// This closes the entire channel, not just the write half.
-    ///
-    /// The channel is automatically closed when both the `L2capChannelWriter`
-    /// and `L2capChannelReader` are dropped, so you don't need to call this explicitly.
-    #[inline]
-    pub async fn close(&mut self) -> Result<()> {
-        self.writer.close().await
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        self.channel.as_mut().poll_shutdown(cx)
     }
 }

--- a/src/l2cap_channel.rs
+++ b/src/l2cap_channel.rs
@@ -1,8 +1,6 @@
-use std::{
-    io::Result,
-    pin::Pin,
-    task::{Context, Poll},
-};
+use std::io::Result;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,6 @@ mod characteristic;
 mod descriptor;
 mod device;
 pub mod error;
-mod l2cap_channel;
 pub mod pairing;
 mod service;
 mod util;
@@ -143,7 +142,6 @@ pub use characteristic::Characteristic;
 pub use descriptor::Descriptor;
 pub use device::{Device, ServicesChanged};
 pub use error::Error;
-pub use l2cap_channel::{L2capChannel, L2capChannelReader, L2capChannelWriter};
 pub use service::Service;
 pub use sys::DeviceId;
 #[cfg(not(target_os = "linux"))]
@@ -157,6 +155,17 @@ use crate::bluer as sys;
 use crate::corebluetooth as sys;
 #[cfg(target_os = "windows")]
 use crate::windows as sys;
+
+#[cfg(all(
+    feature = "l2cap",
+    any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "ios")
+))]
+mod l2cap_channel;
+#[cfg(all(
+    feature = "l2cap",
+    any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "ios")
+))]
+pub use l2cap_channel::L2capChannel;
 
 /// Convenience alias for a result with [`Error`]
 pub type Result<T, E = Error> = core::result::Result<T, E>;

--- a/src/windows/device.rs
+++ b/src/windows/device.rs
@@ -277,7 +277,7 @@ impl DeviceImpl {
         &self,
         _psm: u16,
         _secure: bool,
-    ) -> std::prelude::v1::Result<(L2capChannelReader, L2capChannelWriter), crate::Error> {
+    ) -> Result<(L2capChannelReader, L2capChannelWriter)> {
         Err(ErrorKind::NotSupported.into())
     }
 }

--- a/src/windows/device.rs
+++ b/src/windows/device.rs
@@ -273,6 +273,7 @@ impl DeviceImpl {
         Err(ErrorKind::NotSupported.into())
     }
 
+    #[cfg(feature = "l2cap")]
     pub async fn open_l2cap_channel(
         &self,
         _psm: u16,

--- a/src/windows/l2cap_channel.rs
+++ b/src/windows/l2cap_channel.rs
@@ -2,51 +2,24 @@ use std::fmt;
 
 use crate::Result;
 
-pub struct L2capChannelReader {
-    _private: (),
-}
+pub struct Channel {}
 
-impl L2capChannelReader {
-    #[inline]
-    pub async fn read(&mut self, _buf: &mut [u8]) -> Result<usize> {
-        todo!()
-    }
-
-    pub fn try_read(&mut self, _buf: &mut [u8]) -> Result<usize> {
-        todo!()
-    }
-
-    pub async fn close(&mut self) -> Result<()> {
-        todo!()
+impl AsyncRead for Channel {
+    fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>) -> Poll<std::io::Result<()>> {
+        unimplemented!()
     }
 }
 
-impl fmt::Debug for L2capChannelReader {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("L2capChannelReader")
-    }
-}
-
-pub struct L2capChannelWriter {
-    _private: (),
-}
-
-impl L2capChannelWriter {
-    pub async fn write(&mut self, _packet: &[u8]) -> Result<()> {
-        todo!()
+impl AsyncWrite for Channel {
+    fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize>> {
+        unimplemented!()
     }
 
-    pub fn try_write(&mut self, _packet: &[u8]) -> Result<()> {
-        todo!()
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        unimplemented!()
     }
 
-    pub async fn close(&mut self) -> Result<()> {
-        todo!()
-    }
-}
-
-impl fmt::Debug for L2capChannelWriter {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("L2capChannelWriter")
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        unimplemented!()
     }
 }


### PR DESCRIPTION
Partly Addresses #3.

This PR does 3 things.
- Adds a feature flag for enabling and disabling L2Cap channel support.
- Changes the L2Cap implementation to implement `AsyncRead + AsyncWrite`. These traits seem better than using custom `read` and `write` methods as they integrate better with the rest of the rust async ecosystem. They also have [`read`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncReadExt.html#method.read) and [`write`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncWriteExt.html#method.write) methods. I am using the tokio versions instead of the futures versions because the bluer (Linux) implementation relies on the tokio version and making an adapter seems like unnecessary complexity. I also think it is important to keep the interface the same for all platforms. Note that `bluest` can still be used without tokio if the `l2cap` feature is disabled.
- Adds L2Cap channel support to Linux and CoreBluetooth.

I have only tested on MacOS, IOS, and Linux. I have written an android implementation but it may have bugs, or be entirely the wrong way of doing things. @Dirbaio can you take a look at the android code?