### PR TITLE
Implement std::fmt::Display for DeviceId on Linux

### DIFF
--- a/src/bluer.rs
+++ b/src/bluer.rs
@@ -11,3 +11,9 @@ mod error;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceId(bluer::Address);
+
+impl std::fmt::Display for DeviceId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}


### PR DESCRIPTION
Supplement the missing implementation of `Display` on Linux