### PR TITLE
feat: introduce adapter config for platform-specific configuration options

### DIFF
--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         )
         .init();
 
-    let adapter = Adapter::default().await.ok_or("Bluetooth adapter not found")?;
+    let adapter = Adapter::default().await?;
     adapter.wait_available().await?;
 
     info!("looking for device");

--- a/examples/connect.rs
+++ b/examples/connect.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         )
         .init();
 
-    let adapter = Adapter::default().await.ok_or("Bluetooth adapter not found")?;
+    let adapter = Adapter::default().await?;
     adapter.wait_available().await?;
 
     let discovered_device = {

--- a/examples/connected.rs
+++ b/examples/connected.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         )
         .init();
 
-    let adapter = Adapter::default().await.ok_or("Bluetooth adapter not found")?;
+    let adapter = Adapter::default().await?;
     adapter.wait_available().await?;
 
     info!("getting connected devices");

--- a/examples/pair.rs
+++ b/examples/pair.rs
@@ -82,7 +82,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         )
         .init();
 
-    let adapter = Adapter::default().await.ok_or("Bluetooth adapter not found")?;
+    let adapter = Adapter::default().await?;
     adapter.wait_available().await?;
 
     let discovered_device = {

--- a/examples/scan.rs
+++ b/examples/scan.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         )
         .init();
 
-    let adapter = Adapter::default().await.ok_or("Bluetooth adapter not found")?;
+    let adapter = Adapter::default().await?;
     adapter.wait_available().await?;
 
     info!("starting scan");

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -10,26 +10,19 @@ use crate::{sys, AdapterEvent, AdvertisingDevice, ConnectionEvent, Device, Devic
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Adapter(sys::adapter::AdapterImpl);
 
+/// Configuration options when creating the Bluetooth adapter interface.
+pub type AdapterConfig = sys::adapter::AdapterConfig;
+
 impl Adapter {
-    /// Creates an interface to the default Bluetooth adapter for the system.
-    ///
-    /// # Safety
-    ///
-    /// - `java_vm` must be a valid JNI `JavaVM` pointer to a VM that will stay alive for the entire duration the `Adapter` or any structs obtained from it are live.
-    /// - `bluetooth_manager` must be a valid global reference to an `android.bluetooth.BluetoothManager` instance, from the `java_vm` VM.
-    /// - The `Adapter` takes ownership of the global reference and will delete it with the `DeleteGlobalRef` JNI call when dropped. You must not do that yourself.
-    #[cfg(target_os = "android")]
-    pub unsafe fn new(
-        java_vm: *mut java_spaghetti::sys::JavaVM,
-        bluetooth_manager: java_spaghetti::sys::jobject,
-    ) -> Result<Self> {
-        sys::adapter::AdapterImpl::new(java_vm, bluetooth_manager).map(Self)
+    /// Creates an interface to the default Bluetooth adapter for the system using
+    /// the provided config.
+    pub async fn with_config(config: AdapterConfig) -> Result<Self> {
+        sys::adapter::AdapterImpl::with_config(config).await.map(Adapter)
     }
 
-    /// Creates an interface to the default Bluetooth adapter for the system
-    #[inline]
+    /// Creates an interface to the default Bluetooth adapter for the system.
     #[cfg(not(target_os = "android"))]
-    pub async fn default() -> Option<Self> {
+    pub async fn default() -> Result<Self> {
         sys::adapter::AdapterImpl::default().await.map(Adapter)
     }
 

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -19,7 +19,7 @@ impl Adapter {
         sys::adapter::AdapterImpl::with_config(config).await.map(Adapter)
     }
 
-    /// Creates an interface to a Bluetooth adapter using the provided config.
+    /// Creates an interface to a Bluetooth adapter using the default config.
     pub async fn default() -> Result<Self> {
         sys::adapter::AdapterImpl::with_config(AdapterConfig::default())
             .await

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -20,6 +20,8 @@ impl Adapter {
     }
 
     /// Creates an interface to a Bluetooth adapter using the default config.
+    #[inline]
+    #[cfg(not(target_os = "android"))]
     pub async fn default() -> Result<Self> {
         sys::adapter::AdapterImpl::with_config(AdapterConfig::default())
             .await

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -14,16 +14,9 @@ pub struct Adapter(sys::adapter::AdapterImpl);
 pub type AdapterConfig = sys::adapter::AdapterConfig;
 
 impl Adapter {
-    /// Creates an interface to the default Bluetooth adapter for the system using
-    /// the provided config.
+    /// Creates an interface to a Bluetooth adapter using the provided config.
     pub async fn with_config(config: AdapterConfig) -> Result<Self> {
         sys::adapter::AdapterImpl::with_config(config).await.map(Adapter)
-    }
-
-    /// Creates an interface to the default Bluetooth adapter for the system.
-    #[cfg(not(target_os = "android"))]
-    pub async fn default() -> Result<Self> {
-        sys::adapter::AdapterImpl::default().await.map(Adapter)
     }
 
     /// A stream of [`AdapterEvent`] which allows the application to identify when the adapter is enabled or disabled.

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -19,6 +19,13 @@ impl Adapter {
         sys::adapter::AdapterImpl::with_config(config).await.map(Adapter)
     }
 
+    /// Creates an interface to a Bluetooth adapter using the provided config.
+    pub async fn default() -> Result<Self> {
+        sys::adapter::AdapterImpl::with_config(AdapterConfig::default())
+            .await
+            .map(Adapter)
+    }
+
     /// A stream of [`AdapterEvent`] which allows the application to identify when the adapter is enabled or disabled.
     #[inline]
     pub async fn events(&self) -> Result<impl Stream<Item = Result<AdapterEvent>> + Send + Unpin + '_> {

--- a/src/android/adapter.rs
+++ b/src/android/adapter.rs
@@ -66,7 +66,7 @@ impl AdapterConfig {
 }
 
 impl AdapterImpl {
-    /// Creates an interface to the default Bluetooth adapter for the system.
+    /// Creates an interface to a Bluetooth adapter.
     ///
     /// # Safety
     ///

--- a/src/android/adapter.rs
+++ b/src/android/adapter.rs
@@ -34,24 +34,66 @@ pub struct AdapterImpl {
     inner: Arc<AdapterInner>,
 }
 
+/// Creates an interface to the default Bluetooth adapter for the system.
+///
+/// # Safety
+///
+/// - The `Adapter` takes ownership of the global reference and will delete it with the `DeleteGlobalRef` JNI call when dropped. You must not do that yourself.
+pub struct AdapterConfig {
+    /// - `vm` must be a valid JNI `JavaVM` pointer to a VM that will stay alive for the entire duration the `Adapter` or any structs obtained from it are live.
+    vm: *mut java_spaghetti::sys::JavaVM,
+    /// - `manager` must be a valid global reference to an `android.bluetooth.BluetoothManager` instance, from the `java_vm` VM.
+    manager: java_spaghetti::sys::jobject,
+}
+
+impl AdapterConfig {
+    /// Creates a config for the default Bluetooth adapter for the system.
+    ///
+    /// # Safety
+    ///
+    /// - `java_vm` must be a valid JNI `JavaVM` pointer to a VM that will stay alive for the entire duration the `Adapter` or any structs obtained from it are live.
+    /// - `bluetooth_manager` must be a valid global reference to an `android.bluetooth.BluetoothManager` instance, from the `java_vm` VM.
+    /// - The `Adapter` takes ownership of the global reference and will delete it with the `DeleteGlobalRef` JNI call when dropped. You must not do that yourself.
+    pub unsafe fn new(
+        java_vm: *mut java_spaghetti::sys::JavaVM,
+        bluetooth_manager: java_spaghetti::sys::jobject,
+    ) -> Self {
+        Self {
+            vm: java_vm,
+            manager: bluetooth_manager,
+        }
+    }
+}
+
 impl AdapterImpl {
-    pub unsafe fn new(vm: *mut java_spaghetti::sys::JavaVM, manager: java_spaghetti::sys::jobject) -> Result<Self> {
-        let vm = VM::from_raw(vm);
-        let manager: Global<BluetoothManager> = Global::from_raw(vm, manager);
+    /// Creates an interface to the default Bluetooth adapter for the system.
+    ///
+    /// # Safety
+    ///
+    /// In the config object:
+    ///
+    /// - `vm` must be a valid JNI `JavaVM` pointer to a VM that will stay alive for the entire duration the `Adapter` or any structs obtained from it are live.
+    /// - `manager` must be a valid global reference to an `android.bluetooth.BluetoothManager` instance, from the `java_vm` VM.
+    /// - The `Adapter` takes ownership of the global reference and will delete it with the `DeleteGlobalRef` JNI call when dropped. You must not do that yourself.
+    pub async fn with_config(config: AdapterConfig) -> Result<Self> {
+        unsafe {
+            let vm = VM::from_raw(config.vm);
+            let manager: Global<BluetoothManager> = Global::from_raw(vm, config.manager);
 
-        vm.with_env(|env| {
-            let local_manager = manager.as_ref(env);
-            let adapter = local_manager.getAdapter()?.non_null()?;
-            let le_scanner = adapter.getBluetoothLeScanner()?.non_null()?;
+            vm.with_env(|env| {
+                let local_manager = manager.as_ref(env);
+                let adapter = local_manager.getAdapter()?.non_null()?;
+                let le_scanner = adapter.getBluetoothLeScanner()?.non_null()?;
 
-            Ok(Self {
-                inner: Arc::new(AdapterInner {
-                    _adapter: adapter.as_global(),
-                    le_scanner: le_scanner.as_global(),
-                    manager: manager.clone(),
-                }),
+                Ok(Self {
+                    inner: Arc::new(AdapterInner {
+                        _adapter: adapter.as_global(),
+                        le_scanner: le_scanner.as_global(),
+                        manager: manager.clone(),
+                    }),
+                })
             })
-        })
+        }
     }
 
     pub(crate) async fn events(&self) -> Result<impl Stream<Item = Result<AdapterEvent>> + Send + Unpin + '_> {

--- a/src/bluer/adapter.rs
+++ b/src/bluer/adapter.rs
@@ -10,7 +10,7 @@ use crate::{AdapterEvent, AdvertisingDevice, ConnectionEvent, Device, DeviceId, 
 #[derive(Default)]
 pub struct AdapterConfig {
     /// Name of adapter to use.
-    pub adapter_name: Option<String>,
+    pub name: Option<String>,
 }
 
 /// The system's Bluetooth adapter interface.
@@ -37,16 +37,11 @@ impl std::hash::Hash for AdapterImpl {
 }
 
 impl AdapterImpl {
-    /// Creates an interface to the default Bluetooth adapter for the system
-    pub async fn default() -> Result<Self> {
-        Self::with_config(AdapterConfig::default()).await
-    }
-
-    /// Creates an interface to the default Bluetooth adapter for the system
+    /// Creates an interface to a Bluetooth adapter using the provided config.
     pub async fn with_config(config: AdapterConfig) -> Result<Self> {
         let session = Arc::new(bluer::Session::new().await?);
-        let adapter = if let Some(adapter_name) = config.adapter_name {
-            session.adapter(&adapter_name)
+        let adapter = if let Some(name) = config.name {
+            session.adapter(&name)
         } else {
             session.default_adapter().await
         };

--- a/src/bluer/adapter.rs
+++ b/src/bluer/adapter.rs
@@ -7,6 +7,12 @@ use futures_lite::StreamExt;
 use crate::error::ErrorKind;
 use crate::{AdapterEvent, AdvertisingDevice, ConnectionEvent, Device, DeviceId, Error, Result, Uuid};
 
+#[derive(Default)]
+pub struct AdapterConfig {
+    /// Name of adapter to use.
+    pub adapter_name: Option<String>,
+}
+
 /// The system's Bluetooth adapter interface.
 ///
 /// The default adapter for the system may be accessed with the [`Adapter::default()`] method.
@@ -32,13 +38,20 @@ impl std::hash::Hash for AdapterImpl {
 
 impl AdapterImpl {
     /// Creates an interface to the default Bluetooth adapter for the system
-    pub async fn default() -> Option<Self> {
-        let session = Arc::new(bluer::Session::new().await.ok()?);
-        session
-            .default_adapter()
-            .await
-            .ok()
-            .map(|inner| AdapterImpl { inner, session })
+    pub async fn default() -> Result<Self> {
+        Self::with_config(AdapterConfig::default()).await
+    }
+
+    /// Creates an interface to the default Bluetooth adapter for the system
+    pub async fn with_config(config: AdapterConfig) -> Result<Self> {
+        let session = Arc::new(bluer::Session::new().await?);
+        let adapter = if let Some(adapter_name) = config.adapter_name {
+            session.adapter(&adapter_name)
+        } else {
+            session.default_adapter().await
+        };
+        let adapter = adapter.map(|inner| AdapterImpl { inner, session })?;
+        Ok(adapter)
     }
 
     /// A stream of [`AdapterEvent`] which allows the application to identify when the adapter is enabled or disabled.

--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::let_unit_value)]
 
+use std::ops::Deref;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -8,8 +9,11 @@ use futures_lite::{stream, StreamExt};
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2::{AnyThread, Message};
-use objc2_core_bluetooth::{CBCentralManager, CBManager, CBManagerAuthorization, CBManagerState, CBUUID};
-use objc2_foundation::{NSArray, NSData, NSUUID};
+use objc2_core_bluetooth::{
+    CBCentralManager, CBCentralManagerOptionShowPowerAlertKey, CBManager, CBManagerAuthorization, CBManagerState,
+    CBUUID,
+};
+use objc2_foundation::{NSArray, NSData, NSDictionary, NSNumber, NSString, NSUUID};
 use tracing::{debug, error, info, warn};
 
 use super::delegates::{self, CentralDelegate};
@@ -19,6 +23,12 @@ use crate::util::defer;
 use crate::{
     AdapterEvent, AdvertisingDevice, BluetoothUuidExt, ConnectionEvent, Device, DeviceId, Error, Result, Uuid,
 };
+
+#[derive(Default)]
+pub struct AdapterConfig {
+    /// Enable/disable the power alert dialog when using the adapter.
+    pub show_power_alert: bool,
+}
 
 /// The system's Bluetooth adapter interface.
 ///
@@ -54,7 +64,12 @@ impl std::fmt::Debug for AdapterImpl {
 
 impl AdapterImpl {
     /// Creates an interface to the default Bluetooth adapter for the system
-    pub async fn default() -> Option<Self> {
+    pub async fn default() -> Result<Self> {
+        Self::with_config(AdapterConfig::default()).await
+    }
+
+    /// Creates an interface to the default Bluetooth adapter for the system
+    pub async fn with_config(config: AdapterConfig) -> Result<Self> {
         match unsafe { CBManager::authorization_class() } {
             CBManagerAuthorization::AllowedAlways => info!("Bluetooth authorization is allowed"),
             CBManagerAuthorization::Denied => error!("Bluetooth authorization is denied"),
@@ -69,12 +84,21 @@ impl AdapterImpl {
         let protocol = ProtocolObject::from_retained(delegate.clone());
         let central = unsafe {
             let this = CBCentralManager::alloc();
-            // let options = NSDictionary::from_slices(&[CBCentralManagerOptionShowPowerAlertKey], &[NSNumber::numberWithBool(config.request_permissions)]);
-            CBCentralManager::initWithDelegate_queue(this, Some(&protocol), Some(dispatch::queue()))
+
+            let options: Retained<NSDictionary<NSString>> = NSDictionary::from_retained_objects(
+                &[CBCentralManagerOptionShowPowerAlertKey],
+                &[NSNumber::numberWithBool(config.show_power_alert).into()],
+            );
+            CBCentralManager::initWithDelegate_queue_options(
+                this,
+                Some(&protocol),
+                Some(dispatch::queue()),
+                Some(options.deref()),
+            )
         };
         let central = unsafe { Dispatched::new(central) };
 
-        Some(AdapterImpl {
+        Ok(AdapterImpl {
             central,
             delegate,
             scanning: Default::default(),

--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -63,12 +63,7 @@ impl std::fmt::Debug for AdapterImpl {
 }
 
 impl AdapterImpl {
-    /// Creates an interface to the default Bluetooth adapter for the system
-    pub async fn default() -> Result<Self> {
-        Self::with_config(AdapterConfig::default()).await
-    }
-
-    /// Creates an interface to the default Bluetooth adapter for the system
+    /// Creates an interface to a Bluetooth adapter using the provided config.
     pub async fn with_config(config: AdapterConfig) -> Result<Self> {
         match unsafe { CBManager::authorization_class() } {
             CBManagerAuthorization::AllowedAlways => info!("Bluetooth authorization is allowed"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //!# use futures_lite::StreamExt;
 //!# #[tokio::main]
 //!# async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!let adapter = Adapter::default().await.ok_or("Bluetooth adapter not found")?;
+//!let adapter = Adapter::default().await?;
 //!adapter.wait_available().await?;
 //!
 //!println!("starting scan");
@@ -146,7 +146,7 @@ use std::collections::HashMap;
 
 #[cfg(target_os = "linux")]
 pub use ::bluer::Uuid;
-pub use adapter::Adapter;
+pub use adapter::{Adapter, AdapterConfig};
 pub use btuuid::BluetoothUuidExt;
 pub use characteristic::Characteristic;
 pub use descriptor::Descriptor;

--- a/src/windows/adapter.rs
+++ b/src/windows/adapter.rs
@@ -29,8 +29,8 @@ use crate::{
 
 #[derive(Default)]
 pub struct AdapterConfig {
-    /// Name of adapter to use.
-    pub adapter_name: Option<String>,
+    /// Device ID to use.
+    pub device_id: Option<String>,
 }
 
 /// The system's Bluetooth adapter interface.
@@ -62,16 +62,11 @@ impl std::fmt::Debug for AdapterImpl {
 }
 
 impl AdapterImpl {
-    /// Creates an interface to the default Bluetooth adapter for the system
-    pub async fn default() -> Result<Self> {
-        Self::with_config(AdapterConfig::default()).await
-    }
-
-    /// Creates an interface to the default Bluetooth adapter for the system
+    /// Creates an interface to a Bluetooth adapter using the provided config.
     pub async fn with_config(config: AdapterConfig) -> Result<Self> {
-        let adapter = if let Some(adapter_name) = config.adapter_name {
-            let adapter_name = HSTRING::from(&adapter_name);
-            BluetoothAdapter::FromIdAsync(&adapter_name)?.await?
+        let adapter = if let Some(device_id) = config.device_id {
+            let device_id = HSTRING::from(&device_id);
+            BluetoothAdapter::FromIdAsync(&device_id)?.await?
         } else {
             BluetoothAdapter::GetDefaultAsync()?.await?
         };

--- a/tests/check_api.rs
+++ b/tests/check_api.rs
@@ -110,9 +110,10 @@ async fn check_descriptor_apis(descriptor: Descriptor) -> Result<()> {
 #[allow(unused)]
 async fn check_apis() -> Result<()> {
     #[cfg(target_os = "android")]
-    let adapter: Result<Adapter> = unsafe { Adapter::new(core::ptr::null_mut(), core::ptr::null_mut()) };
+    let adapter: Result<Adapter> =
+        Adapter::with_config(unsafe { AdapterConfig::new(core::ptr::null_mut(), core::ptr::null_mut()) }).await;
     #[cfg(not(target_os = "android"))]
-    let adapter: Option<Adapter> = assert_send(Adapter::default()).await;
+    let adapter: Result<Adapter> = assert_send(Adapter::default()).await;
     let device = check_adapter_apis(adapter.unwrap()).await?;
     let service = check_device_apis(device).await?;
     let characteristic = check_service_apis(service).await?;


### PR DESCRIPTION
Breaks the public API a bit, let me know if it should be preserved. Also I put unsafe on creating the config on android, this way the with_config on the adapter could still be the same for all platforms.