### PR TITLE
android: Fix clippy error in Rust 1.89 Android Bindings

### DIFF
--- a/src/android.rs
+++ b/src/android.rs
@@ -10,6 +10,7 @@ pub mod device;
 pub mod l2cap_channel;
 pub mod service;
 
+#[allow(mismatched_lifetime_syntaxes)]
 pub(crate) mod bindings;
 
 /// A platform-specific device identifier.


### PR DESCRIPTION
There is a clippy warning in rust 1.89 that is cause all of android CI to fail. (https://github.com/alexmoon/bluest/actions/runs/17018037851/job/48243206290?pr=39)

The error is in autogenerated code, so I think it should just be supressed.