### PR TITLE
Add pair guard on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.6.10 [in progress]
+
+- (Windows) `pair()` and `pair_with_agent()` now result in a `no-op` if the device is already paired (same behavior as Linux)
+
 ## 0.6.9
 
 - (MacOS/iOS) Update to `objc2` crates

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bluest"
-version = "0.6.9"
+version = "0.6.10"
 authors = ["Alex Moon"]
 edition = "2021"
 description = "A cross-platform Bluetooth Low Energy (BLE) library"

--- a/src/bluer/device.rs
+++ b/src/bluer/device.rs
@@ -97,7 +97,7 @@ impl DeviceImpl {
         self.inner.pair().await.map_err(Into::into)
     }
 
-    /// Attempt to pair this device using the system default pairing UI
+    /// Attempt to pair this device using the provided agent
     pub async fn pair_with_agent<T: PairingAgent + 'static>(&self, agent: &T) -> Result<()> {
         if self.is_paired().await? {
             return Ok(());

--- a/src/corebluetooth/device.rs
+++ b/src/corebluetooth/device.rs
@@ -112,7 +112,7 @@ impl DeviceImpl {
         Ok(())
     }
 
-    /// Attempt to pair this device using the system default pairing UI
+    /// Attempt to pair this device using the provided agent
     ///
     /// Device pairing is performed automatically by the OS when a characteristic requiring security is accessed. This
     /// method is a no-op.

--- a/src/windows/device.rs
+++ b/src/windows/device.rs
@@ -118,6 +118,9 @@ impl DeviceImpl {
     ///
     /// This will fail unless it is called from a UWP application.
     pub async fn pair(&self) -> Result<()> {
+        if self.is_paired().await? {
+            return Ok(());
+        }
         let op = self.inner.DeviceInformation()?.Pairing()?.PairAsync()?;
         let res = op.await?;
         check_pairing_status(res.Status()?)
@@ -125,6 +128,9 @@ impl DeviceImpl {
 
     /// Attempt to pair this device using the provided agent
     pub async fn pair_with_agent<T: PairingAgent>(&self, agent: &T) -> Result<()> {
+        if self.is_paired().await? {
+            return Ok(());
+        }
         let pairing_kinds_supported = match agent.io_capability() {
             IoCapability::DisplayOnly => DevicePairingKinds::DisplayPin,
             IoCapability::DisplayYesNo => {

--- a/src/windows/device.rs
+++ b/src/windows/device.rs
@@ -123,7 +123,7 @@ impl DeviceImpl {
         check_pairing_status(res.Status()?)
     }
 
-    /// Attempt to pair this device using the system default pairing UI
+    /// Attempt to pair this device using the provided agent
     pub async fn pair_with_agent<T: PairingAgent>(&self, agent: &T) -> Result<()> {
         let pairing_kinds_supported = match agent.io_capability() {
             IoCapability::DisplayOnly => DevicePairingKinds::DisplayPin,


### PR DESCRIPTION
Align the Windows implementation to the Linux one, where `pair()` and `pair_with_agent()` are a `no-op` if the device is already paired.

Fixes #42 

**NOTE**
I don't know how you handle releases, therefore I'm not sure if it's okay to change `Cargo.toml` or you have an automated way for doing doing so